### PR TITLE
Removed column join

### DIFF
--- a/quickbase.py
+++ b/quickbase.py
@@ -293,7 +293,7 @@ class Client(object):
             request['qname'] = qname
 
         if columns:
-            request['clist'] = '.'.join(str(c) for c in columns)
+            request['clist'] = columns
         if sort:
             request['slist'] = '.'.join(str(c) for c in sort)
         if structured:


### PR DESCRIPTION
Column list parsing of a number greater then 10 was returning a period
delimited string which resulted in the wrong columns returned from
QuickBase.

```
list = '1234'
print('.'.join(str(c) for c in list))
# returns 1.2.3.4
```

Removed the join (likely not the best solution) but now I can return
columns greater then ID 10.
