### PR TITLE
Streaming Requests to files to save memory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ pyQuickBase is an MIT licensed client library for the Intuit QuickBase API, usin
 Version
 -------
 
+0.2.5
+-----
+- Added streaming to the request function, (saves request to temp file '.request')
+
 0.2.4
 -----
 - Fixed _parse_records to check for <url> child in structured record fields (for file downloading).

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Version
 
 0.2.5
 -----
-- Added streaming to the request function, (saves request to temp file '.request')
+- Added streaming to the request function.
 
 0.2.4
 -----

--- a/quickbase.py
+++ b/quickbase.py
@@ -216,12 +216,14 @@ class Client(object):
             'Content-Type': 'application/xml',
             'QUICKBASE-ACTION': 'API_' + action,
         }
-        request = requests.post(url, data, headers=headers)
-        response = request.content
-        encoding = chardet.detect(response)['encoding']
-
-        if encoding != 'utf-8':
-            response = response.decode(encoding, 'replace').encode('utf-8')
+        response = ""
+        request = requests.post(url, data, headers=headers, stream=True)
+        if request.status_code == 200:
+            for chunk in request.iter_content(2048):
+                encode = chardet.detect(chunk)['encoding']
+                if encode != 'utf-8':
+                    chunk = chunk.decode(encode, 'replace').encode('utf-8')
+                response += chunk
 
         try:
             parsed = etree.fromstring(response)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name='pyquickbase',
-    version='0.2.3',
+    version='0.2.5',
     author='Kevin V Seelbach',
     author_email='kevin.seelbach@gmail.com',
     py_modules=['quickbase'],


### PR DESCRIPTION
When working with massive query results (2000+ records) doing a `encoding = chardet.detect(response)['encoding']` on the whole response object takes not only a lot of time, but a lot of memory to do the check and later replace if there are non UTF-8 characters.

Changing request to Stream=True means we can check each chunk for non UTF-8 characters and replace them in a more efficient manner and without ballooning our memory usage. 
